### PR TITLE
TTV.LOL adblocker, Clips fixed and Moved Refresh stream to a more suitable location

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/api/TTVLolApi.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/api/TTVLolApi.kt
@@ -1,0 +1,21 @@
+package com.github.andreyasadchy.xtra.api;
+
+import okhttp3.ResponseBody
+import retrofit2.Response
+
+import kotlin.jvm.JvmSuppressWildcards;
+import retrofit2.http.GET;
+import retrofit2.http.Path
+import retrofit2.http.QueryMap
+
+@JvmSuppressWildcards
+interface TTVLolApi {
+
+
+    @GET("playlist/{channel}.m3u8")
+    suspend fun getPlaylist(@Path("channel") channel: String, @QueryMap options: Map<String, String>): Response<ResponseBody>
+
+    @GET("ping")
+    suspend fun ping(): Response<ResponseBody>
+
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/di/XtraModule.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/di/XtraModule.kt
@@ -4,12 +4,7 @@ import android.app.Application
 import android.os.Build
 import android.util.Log
 import com.github.andreyasadchy.xtra.BuildConfig
-import com.github.andreyasadchy.xtra.api.ApiService
-import com.github.andreyasadchy.xtra.api.GraphQLApi
-import com.github.andreyasadchy.xtra.api.IdApi
-import com.github.andreyasadchy.xtra.api.KrakenApi
-import com.github.andreyasadchy.xtra.api.MiscApi
-import com.github.andreyasadchy.xtra.api.UsherApi
+import com.github.andreyasadchy.xtra.api.*
 import com.github.andreyasadchy.xtra.model.chat.FfzEmotesResponse
 import com.github.andreyasadchy.xtra.model.chat.FfzRoomDeserializer
 import com.github.andreyasadchy.xtra.model.chat.SubscriberBadgeDeserializer
@@ -117,6 +112,22 @@ class XtraModule {
                 .addConverterFactory(gsonConverterFactory)
                 .build()
                 .create(IdApi::class.java)
+    }
+
+    @Singleton
+    @Provides
+    fun providesTTVLolApi(client: OkHttpClient, gsonConverterFactory: GsonConverterFactory): TTVLolApi {
+        return Retrofit.Builder()
+                .baseUrl("https://api.ttv.lol/")
+                .client(client.newBuilder().addInterceptor { chain ->
+                    val request = chain.request().newBuilder()
+                            .addHeader("X-Donate-To", "https://ttv.lol/donate")
+                            .build()
+                    chain.proceed(request)
+                }.build())
+                .addConverterFactory(gsonConverterFactory)
+                .build()
+                .create(TTVLolApi::class.java)
     }
 
     @Singleton

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/gql/clip/ClipDataDeserializer.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/gql/clip/ClipDataDeserializer.kt
@@ -17,7 +17,7 @@ class ClipDataDeserializer : JsonDeserializer<ClipDataResponse> {
             videos.add(ClipDataResponse.Video(
                     video.getAsJsonPrimitive("frameRate").asInt,
                     video.getAsJsonPrimitive("quality").asString,
-                    video.getAsJsonPrimitive("sourceURL").asString))
+                    video.getAsJsonPrimitive("sourceURL").asString.replace(Regex("https://[^/]+"),"https://clips-media-assets2.twitch.tv")))
         }
         return ClipDataResponse(videos)
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLRepositoy.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLRepositoy.kt
@@ -48,7 +48,7 @@ class GraphQLRepositoy @Inject constructor(private val graphQL: GraphQLApi) {
             add("extensions", JsonObject().apply {
                 add("persistedQuery", JsonObject().apply {
                     addProperty("version", 1)
-                    addProperty("sha256Hash", "9bfcc0177bffc730bd5a5a89005869d2773480cf1738c592143b5173634b7d15")
+                    addProperty("sha256Hash", "36b89d2507fce29e5ca551df756d27c1cfe079e2609642b4390aa4c35796eb11")
                 })
             })
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/HlsPlayerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/HlsPlayerViewModel.kt
@@ -15,6 +15,7 @@ import com.github.andreyasadchy.xtra.ui.player.PlayerMode.AUDIO_ONLY
 import com.github.andreyasadchy.xtra.ui.player.PlayerMode.NORMAL
 import com.github.andreyasadchy.xtra.ui.player.stream.StreamPlayerViewModel
 import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.prefs
 import com.google.android.exoplayer2.Timeline
 import com.google.android.exoplayer2.source.TrackGroupArray
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
@@ -29,7 +30,8 @@ abstract class HlsPlayerViewModel(
         context: Application,
         val repository: TwitchService) : PlayerViewModel(context), FollowViewModel {
 
-    private val prefs = context.getSharedPreferences(C.USER_PREFS, MODE_PRIVATE)
+    private val userPrefs = context.getSharedPreferences(C.USER_PREFS, MODE_PRIVATE)
+    val prefs = context.prefs();
     protected val helper = PlayerHelper()
     val loaded: LiveData<Boolean>
         get() = helper.loaded
@@ -41,6 +43,10 @@ abstract class HlsPlayerViewModel(
         qualityIndex = index
     }
 
+    fun useAdBlock() : Boolean{
+        return prefs.getBoolean(C.AD_BLOCKER,true)
+    }
+
     protected fun setVideoQuality(index: Int) {
         val quality = if (index == 0) {
             trackSelector.setParameters(trackSelector.buildUponParameters().clearSelectionOverrides())
@@ -49,7 +55,7 @@ abstract class HlsPlayerViewModel(
             updateVideoQuality()
             qualities[index]
         }
-        prefs.edit { putString(TAG, quality) }
+        userPrefs.edit { putString(TAG, quality) }
         val mode = _playerMode.value
         if (mode != NORMAL) {
             _playerMode.value = NORMAL
@@ -75,7 +81,7 @@ abstract class HlsPlayerViewModel(
         if (trackSelector.currentMappedTrackInfo != null) {
             if (helper.loaded.value != true) {
                 helper.loaded.value = true
-                val index = prefs.getString(TAG, "Auto").let { quality ->
+                val index = userPrefs.getString(TAG, "Auto").let { quality ->
                     if (quality == "Auto") {
                         0
                     } else {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerViewModel.kt
@@ -27,6 +27,7 @@ import com.google.android.exoplayer2.SimpleExoPlayer
 import com.google.android.exoplayer2.source.MediaSource
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory
+import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory
 import com.google.android.exoplayer2.upstream.HttpDataSource
 import com.google.android.exoplayer2.util.Util
 import com.google.firebase.crashlytics.FirebaseCrashlytics
@@ -39,7 +40,11 @@ abstract class PlayerViewModel(context: Application) : BaseAndroidViewModel(cont
 
     protected val tag: String = javaClass.simpleName
 
-    protected val dataSourceFactory = DefaultDataSourceFactory(context, Util.getUserAgent(context, context.getString(R.string.app_name)))
+    protected val httpDataSourceFactory = DefaultHttpDataSourceFactory(Util.getUserAgent(context, context.getString(R.string.app_name)))
+    protected val dataSourceFactory = DefaultDataSourceFactory(context, null, httpDataSourceFactory)
+
+
+
     protected val trackSelector = DefaultTrackSelector()
     val player: SimpleExoPlayer = ExoPlayerFactory.newSimpleInstance(
             context,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/stream/StreamPlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/stream/StreamPlayerFragment.kt
@@ -67,7 +67,7 @@ class StreamPlayerFragment : BasePlayerFragment() {
         settings.setOnClickListener {
             FragmentUtils.showRadioButtonDialogFragment(childFragmentManager, viewModel.qualities, viewModel.qualityIndex)
         }
-        resume.setOnClickListener {
+        restart.setOnClickListener {
             viewModel.restartPlayer()
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
@@ -69,6 +69,7 @@ class SettingsActivity : AppCompatActivity(), PreferenceFragmentCompat.OnPrefere
             findPreference<ListPreference>(C.LANDSCAPE_COLUMN_COUNT)!!.onPreferenceChangeListener = changeListener
             findPreference<SwitchPreferenceCompat>(C.ANIMATED_EMOTES)!!.onPreferenceChangeListener = changeListener
             findPreference<SwitchPreferenceCompat>(C.COMPACT_STREAMS)!!.onPreferenceChangeListener = changeListener
+            findPreference<SwitchPreferenceCompat>(C.AD_BLOCKER)!!.onPreferenceChangeListener = changeListener
             findPreference<ListPreference>("playerForward")!!.onPreferenceChangeListener = changeListener
             findPreference<ListPreference>("playerRewind")!!.onPreferenceChangeListener = changeListener
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
@@ -23,4 +23,5 @@ object C {
     const val COMPACT_STREAMS = "compactStreams"
     const val IGNORE_NOTCH = "ignoreNotch"
     const val LAST_UPDATE_VERSION = "lastUpdateVersion"
+    const val AD_BLOCKER = "adblock"
 }

--- a/app/src/main/res/layout/player_stream.xml
+++ b/app/src/main/res/layout/player_stream.xml
@@ -4,8 +4,7 @@
     android:layout_height="match_parent"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <View
-        style="@style/PlayerShadow" />
+    <View style="@style/PlayerShadow" />
 
     <ImageButton
         style="@style/PlayerPlay"/>
@@ -13,15 +12,11 @@
     <ImageButton
         style="@style/PlayerPause"/>
 
-    <ImageButton
-        style="@style/PlayerMinimize"/>
+    <ImageButton style="@style/PlayerMinimize" />
 
-    <TextView
-        style="@style/PlayerChannel"/>
+    <TextView style="@style/PlayerChannel" />
 
-    <ImageButton
-        android:id="@+id/resume"
-        style="@style/PlayerResume"/>
+
 
     <LinearLayout
         style="@style/PlayerTopRightPanel">
@@ -91,6 +86,20 @@
 
         <ImageButton
             style="@style/PlayerFullscreenToggle"/>
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="false"
+        android:layout_alignParentRight="false"
+        android:layout_alignParentBottom="true"
+        android:layout_marginBottom="5dp">
+
+        <ImageButton
+            android:id="@+id/restart"
+            style="@style/PlayerRestart" />
 
     </LinearLayout>
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -223,4 +223,6 @@
     <string name="disable">Disable</string>
     <string name="ignore_notch">Ignore camera notch</string>
     <string name="display_beyond_notch">Display video beyond the notch/hole-punch</string>
+    <string name="adblock_desc">يستخدم ابإي  ttv.lol لتحميل تدفقات مجانية استخدم بلوك دعايات ماعا</string>
+    <string name="adblock">استخدم Adblocker</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -164,4 +164,6 @@
     <string name="disable">Desactivado</string>
     <string name="ignore_notch">Ignorar cámara notch</string>
     <string name="display_beyond_notch">Muestre el video más allá del notch</string>
+    <string name="adblock_desc">Utiliza la api de TTV.LOL para cargar transmisiones sin publicidad</string>
+    <string name="adblock">Usar Adblocker</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -223,4 +223,6 @@
     <string name="disable">Отключить</string>
     <string name="ignore_notch">Игнорировать вырез</string>
     <string name="display_beyond_notch">Отображать видео под вырезом для камеры</string>
+    <string name="adblock_desc">Использует API TTV.LOL для загрузки потоков без рекламы</string>
+    <string name="adblock">Используйте Adblocker</string>
 </resources>

--- a/app/src/main/res/values/player.xml
+++ b/app/src/main/res/values/player.xml
@@ -126,6 +126,14 @@
         <item name="android:layout_marginEnd">10dp</item>
     </style>
 
+    <style name="PlayerRestart" parent="PlayerSmallImage">
+        <item name="android:src">@drawable/baseline_replay_black_24</item>
+        <item name="android:layout_alignParentEnd">false</item>
+        <item name="android:layout_alignParentRight">true</item>
+        <item name="android:layout_marginRight">10dp</item>
+        <item name="android:layout_marginEnd">10dp</item>
+    </style>
+
     <style name="PlayerResume" parent="PlayerLargeImage">
         <item name="android:src">@drawable/baseline_fast_forward_black_48</item>
         <item name="android:layout_centerVertical">true</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,6 +103,8 @@
     <string name="player_error">Player error. Retrying</string>
     <string name="picture_in_picture">Picture-in-Picture</string>
     <string name="continue_playback">Continue playback outside of the app</string>
+    <string name="adblock_desc">Uses the TTV.LOL api to load adfree streams </string>
+    <string name="adblock" translatable="false">Use Adblocker</string>
     <string name="source_vod_start">Start: %s</string>
     <string name="source_vod_end">End: %s</string>
     <string name="stream_ended">The stream has ended</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -85,6 +85,13 @@
 
     <SwitchPreferenceCompat
         android:defaultValue="true"
+        android:key="adblock"
+        android:summary="@string/adblock_desc"
+        android:title="@string/adblock"
+        app:iconSpaceReserved="false"/>
+
+    <SwitchPreferenceCompat
+        android:defaultValue="true"
         android:key="pictureInPicture"
         android:summary="@string/continue_playback"
         android:title="@string/picture_in_picture"


### PR DESCRIPTION
This includes 3 changes. 

- Fixed the clips not loading issue
- Added TTV.LOL adblocker (with an option to turn it off in the settings, on by default)
- Moved the refresh/fast forward stream button to the lower left because accidentally pressing it was too easy. This is an optional change if you don't want to include it, then you can deny this specific change. 

First time using kotlin so if it looks more java-like than kotlin-like, I apologise. 